### PR TITLE
fix: resolve cant infer state of reactor with multiple parameter constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Reactive state manager based on Flutter Bloc library
 
 <p align="center">
-    <img src="art/reactor-logo.webp" alt="library logo"/>
+    <img src="https://raw.githubusercontent.com/web-pacotes/reactor/master/art/reactor-logo.webp" alt="library logo"/>
 </p>
 
 ## What?

--- a/packages/reactor-svelte/README.md
+++ b/packages/reactor-svelte/README.md
@@ -3,7 +3,7 @@
 Reactive state manager based on Flutter Bloc library using Svelte stores
 
 <p align="center">
-    <img src="../../art/reactor-svelte-logo.webp" alt="library logo"/>
+    <img src="https://raw.githubusercontent.com/web-pacotes/reactor/master/art/reactor-svelte-logo.webp" alt="library logo"/>
 </p>
 
 ![npm version](https://badgen.net/npm/v/@web-pacotes/reactor-svelte) ![npm total downloads](https://badgen.net/npm/dt/@web-pacotes/reactor-svelte) ![bundlephobia bundle size](https://badgen.net/bundlephobia/min/@web-pacotes/reactor-svelte)

--- a/packages/reactor-svelte/package.json
+++ b/packages/reactor-svelte/package.json
@@ -25,7 +25,8 @@
 	"files": [
 		"dist",
 		"!dist/**/*.test.*",
-		"!dist/**/*.spec.*"
+		"!dist/**/*.spec.*",
+		"!dist/**/spec/**"
 	],
 	"repository": {
 		"type": "git",

--- a/packages/reactor-svelte/src/lib/provider.test.ts
+++ b/packages/reactor-svelte/src/lib/provider.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, test } from 'vitest';
 import { cleanup, configure, render, screen } from '@testing-library/svelte';
-import { ParentNotProvidingReactorToChild, ParentProvidingReactorToChild } from './spec/index.js';
+import {
+	ParentNotProvidingReactorToChild,
+	ParentProvidingMultipleParameterConstructorReactorToChild,
+	ParentProvidingReactorToChild
+} from './spec/index.js';
 
 describe('provider', () => {
 	configure({
@@ -17,7 +21,7 @@ describe('provider', () => {
 		render(ParentProvidingReactorToChild, { props: { key: key } });
 		const domValue = (await screen.findByTestId(key)).innerHTML;
 
-		expect(domValue).not.toBeNull();
+		expect(domValue).not.toBe('undefined');
 	});
 
 	test('child can not access reactor if not provided by parent', async () => {
@@ -27,5 +31,16 @@ describe('provider', () => {
 		const domValue = (await screen.findByTestId(key)).innerHTML;
 
 		expect(domValue).toBe('undefined');
+	});
+});
+
+describe('resolve', () => {
+	test('is able to resolve multiple parameter constructor reactor', async () => {
+		const key = 'dom-key';
+
+		render(ParentProvidingMultipleParameterConstructorReactorToChild, { props: { key: key } });
+		const domValue = (await screen.findByTestId(key)).innerHTML;
+
+		expect(domValue).not.toBe('undefined');
 	});
 });

--- a/packages/reactor-svelte/src/lib/provider.ts
+++ b/packages/reactor-svelte/src/lib/provider.ts
@@ -1,5 +1,6 @@
 import { getContext, setContext } from 'svelte';
 import type { Reactor } from './reactor.js';
+import { TypedClass } from './typed.js';
 
 /**
  * Resolves a {@link Reactor} instance that has been provided by the parent component
@@ -11,8 +12,8 @@ import type { Reactor } from './reactor.js';
  *
  * @param type - prototype of the subclass that extends {@link Reactor}.
  */
-export function resolve<E, S>(type: typeof Reactor<E, S>) {
-	return getContext<Reactor<E, S>>(type);
+export function resolve<T>(type: TypedClass<T>) {
+	return getContext<T>(type);
 }
 
 /**

--- a/packages/reactor-svelte/src/lib/reactor.svelte
+++ b/packages/reactor-svelte/src/lib/reactor.svelte
@@ -4,11 +4,12 @@
 	import { onMount } from 'svelte';
 	import { type Reactor } from './reactor.js';
 	import { resolve } from './provider.js';
+	import { TypedClass } from './typed.js';
 
 	/**
 	 * The reactor whose state is being subscribed.
 	 */
-	export let reactor: Reactor<E, S> | typeof Reactor<E, S>;
+	export let reactor: Reactor<E, S> | TypedClass<Reactor<E, S>>;
 
 	/**
 	 * A callback for subscribing to new state changes.

--- a/packages/reactor-svelte/src/lib/spec/index.ts
+++ b/packages/reactor-svelte/src/lib/spec/index.ts
@@ -1,2 +1,3 @@
 export { default as ParentProvidingReactorToChild } from './parent-providing-reactor-to-child.spec.svelte';
+export { default as ParentProvidingMultipleParameterConstructorReactorToChild } from './parent-providing-multiple-parameter-constructor-reactor-to-child.spec.svelte';
 export { default as ParentNotProvidingReactorToChild } from './parent-not-providing-reactor-to-child.spec.svelte';

--- a/packages/reactor-svelte/src/lib/spec/multiple-parameter-constructor-reactor.ts
+++ b/packages/reactor-svelte/src/lib/spec/multiple-parameter-constructor-reactor.ts
@@ -1,0 +1,12 @@
+import { Reactor } from '../reactor.js';
+
+export class MultipleParameterConstructorReactor extends Reactor<void, string> {
+	constructor(arg1: number, arg2: number) {
+		super('');
+
+		this.on<void>(
+			(_, emit) => emit(`${arg1} | ${arg2}`),
+			(event) => event !== undefined
+		);
+	}
+}

--- a/packages/reactor-svelte/src/lib/spec/parent-providing-multiple-parameter-constructor-reactor-to-child.spec.svelte
+++ b/packages/reactor-svelte/src/lib/spec/parent-providing-multiple-parameter-constructor-reactor-to-child.spec.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { ReactorListener, ReactorProvider, resolve } from '../index.js';
+	import AttachDomValueChild from './attach-dom-value.spec.svelte';
+	import { MultipleParameterConstructorReactor } from './multiple-parameter-constructor-reactor.js';
+
+	export let key: string;
+
+	const reactor = new MultipleParameterConstructorReactor(0, 1);
+</script>
+
+<ReactorProvider {reactor}>
+	<AttachDomValueChild {key} callback={() => resolve(MultipleParameterConstructorReactor)} />
+</ReactorProvider>
+
+<ReactorListener reactor={MultipleParameterConstructorReactor} />

--- a/packages/reactor-svelte/src/lib/typed.ts
+++ b/packages/reactor-svelte/src/lib/typed.ts
@@ -5,6 +5,12 @@
 type TypedObject = { type: string };
 
 /**
+ * A type that is useful to identify class definitions. The library uses this type to allow clients
+ * to pass the class of reactors they want to resolve.
+ */
+export type TypedClass<T> = new (...args: never[]) => T;
+
+/**
  * Type guard for objects that represent their types via the `type` property.
  *
  * @param value - the object being type guarded


### PR DESCRIPTION
## Problem

Using `typeof Reactor<E,S>` makes TypeScript deconstruct the concrete Reactor implementation as an object. This means that the `Reactor` class is pre-processed and transformed as `{ initialState: S, add: ... `}.
When declaring parameters on the concrete Reactor constructor, the first parameter overrides the `S` type state, since the `Reactor` abstract class defines a constructor that receives a single parameter, the initial state. By declaring:

```typescript
class CounterReactor extends Reactor<number, number> {
     constructor(name: string){...}
}
```

and using `typeof CounterReactor`, TypeScript will output:

```typescript
{
     initialState: string // should be initialState: number
     add: (number)
     ....
}
```

which obviously cannot be matched with the output of `typeof Reactor<number, number`, since the `S` type has been overridden with `string`. 

The goal of using `typeof Reactor<E, S>` was to extract in some way the class definition so that it could be used to resolve a reactor "of type Reactor<E, S>" at runtime from the parent component. Obviously, the `typeof` operator is being misused here.

## Solution

Replace `typeof Reactor<E, S>` with `new (...args: never[]) => T`.
This is the simplest definition of a class, since all classes require a constructor (hence the `new` keyword), and by not transforming the class as a type, the `S` type is preserved even if a multiple parameter constructor takes place.