### PR TITLE
fix(reactor-svelte): import TypedClass as type

### DIFF
--- a/packages/reactor-svelte/src/lib/provider.ts
+++ b/packages/reactor-svelte/src/lib/provider.ts
@@ -1,6 +1,6 @@
 import { getContext, setContext } from 'svelte';
 import type { Reactor } from './reactor.js';
-import { TypedClass } from './typed.js';
+import type { TypedClass } from './typed.js';
 
 /**
  * Resolves a {@link Reactor} instance that has been provided by the parent component

--- a/packages/reactor-svelte/src/lib/reactor.svelte
+++ b/packages/reactor-svelte/src/lib/reactor.svelte
@@ -4,7 +4,7 @@
 	import { onMount } from 'svelte';
 	import { type Reactor } from './reactor.js';
 	import { resolve } from './provider.js';
-	import { TypedClass } from './typed.js';
+	import type { TypedClass } from './typed.js';
 
 	/**
 	 * The reactor whose state is being subscribed.


### PR DESCRIPTION
## Problem

On version 0.0.3, using `ReactorListener` leads to a type resolution issue on `TypedClass`

> node_modules/@web-pacotes/reactor-svelte/dist/reactor.svelte:20:9: ERROR: No matching export in "node_modules/@web-pacotes/reactor-svelte/dist/typed.js" for import "TypedClass"



## Solution

The `type` keyword must be added when importing `TypedClass` since it's a type and vite bundler will remove the import since types don't exist in JavaScript