### PR TITLE
feat(reactor-svelte): multi reactor provider

### DIFF
--- a/packages/reactor-svelte/src/lib/index.ts
+++ b/packages/reactor-svelte/src/lib/index.ts
@@ -3,3 +3,4 @@ export * from './typed.js';
 export * from './provider.js';
 export { default as ReactorListener } from './reactor.svelte';
 export { default as ReactorProvider } from './provider.svelte';
+export { default as MultiReactorProvider } from './multi-provider.svelte';

--- a/packages/reactor-svelte/src/lib/multi-provider.svelte
+++ b/packages/reactor-svelte/src/lib/multi-provider.svelte
@@ -5,7 +5,9 @@
 	/**
 	 * The reactors that are being provided to children components.
 	 */
-	export let reactors: Reactor<never, never>[];
+
+	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+	export let reactors: Reactor<NonNullable<any>, NonNullable<any>>[];
 
 	reactors.forEach(provide);
 </script>

--- a/packages/reactor-svelte/src/lib/multi-provider.svelte
+++ b/packages/reactor-svelte/src/lib/multi-provider.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { provide } from './provider.js';
+	import { type Reactor } from './reactor.js';
+
+	/**
+	 * The reactors that are being provided to children components.
+	 */
+	export let reactors: Reactor<never, never>[];
+
+	reactors.forEach(provide);
+</script>
+
+<slot />

--- a/packages/reactor-svelte/src/lib/multi-provider.svelte
+++ b/packages/reactor-svelte/src/lib/multi-provider.svelte
@@ -5,7 +5,6 @@
 	/**
 	 * The reactors that are being provided to children components.
 	 */
-
 	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 	export let reactors: Reactor<NonNullable<any>, NonNullable<any>>[];
 

--- a/packages/reactor-svelte/src/lib/multi-provider.test.ts
+++ b/packages/reactor-svelte/src/lib/multi-provider.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, configure, render, screen } from '@testing-library/svelte';
+import { ParentProvidingMultipleReactorToChild } from './spec/index.js';
+
+describe('multi-provider', () => {
+	configure({
+		testIdAttribute: 'id'
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	test('child can access all reactors provided by parent', async () => {
+		const key = 'dom-key';
+
+		render(ParentProvidingMultipleReactorToChild, { props: { key: key } });
+		const domValue = (await screen.findByTestId(key)).innerHTML;
+
+		expect(domValue).not.toContain('undefined');
+	});
+});

--- a/packages/reactor-svelte/src/lib/spec/index.ts
+++ b/packages/reactor-svelte/src/lib/spec/index.ts
@@ -1,3 +1,4 @@
 export { default as ParentProvidingReactorToChild } from './parent-providing-reactor-to-child.spec.svelte';
 export { default as ParentProvidingMultipleParameterConstructorReactorToChild } from './parent-providing-multiple-parameter-constructor-reactor-to-child.spec.svelte';
 export { default as ParentNotProvidingReactorToChild } from './parent-not-providing-reactor-to-child.spec.svelte';
+export { default as ParentProvidingMultipleReactorToChild } from './parent-providing-multiple-reactor-to-child.spec.svelte';

--- a/packages/reactor-svelte/src/lib/spec/parent-providing-multiple-reactor-to-child.spec.svelte
+++ b/packages/reactor-svelte/src/lib/spec/parent-providing-multiple-reactor-to-child.spec.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { MultiReactorProvider, resolve } from '../index.js';
+	import { CounterReactor } from './counter-reactor.js';
+	import { NumberReactor } from './number-reactor.js';
+	import AttachDomValueChild from './attach-dom-value.spec.svelte';
+
+	export let key: string;
+
+	const counter = new CounterReactor();
+	const number = new NumberReactor();
+
+	const reactors = [counter, number];
+</script>
+
+<MultiReactorProvider {reactors}>
+	<AttachDomValueChild
+		{key}
+		callback={() => `${resolve(CounterReactor)}|${resolve(NumberReactor)}`}
+	/>
+</MultiReactorProvider>


### PR DESCRIPTION
This PR adds a component for providing multiple reactor providers to child components, reducing the need to nest multiple `ReactorProvider`.

This is the same as [MultiBlocProvider](https://bloclibrary.dev/flutter-bloc-concepts/#multiblocprovider).